### PR TITLE
[fix] remove kwarg indicator from redirect_to_message

### DIFF
--- a/erpnext_com/api.py
+++ b/erpnext_com/api.py
@@ -63,7 +63,7 @@ def signup(full_name, email, subdomain, plan="Free", distribution="erpnext", res
 			<p>It may take a few minutes before you receive this email.
 			If you don't find it, please check your SPAM folder.</p>
 			<p>After verification, your account will be setup</p>
-			</div>""".format(email), indicator='blue')
+			</div>""".format(email))
 
 	elif status=='retry':
 		return {}
@@ -71,7 +71,7 @@ def signup(full_name, email, subdomain, plan="Free", distribution="erpnext", res
 	else:
 		# something went wrong
 		location = frappe.redirect_to_message(_('Something went wrong'),
-			'Please try again or drop an email to support@erpnext.com', indicator='red')
+			'Please try again or drop an email to support@erpnext.com')
 
 	return {
 		'location': location


### PR DESCRIPTION
In a develop branch, redirect_to_message is defined as

```def redirect_to_message(title, html, http_status_code=None, context=None):```

This not contains kwarg indicator.

Due to this, signup redirect is failing.
```
https://erpnext.com/ Failed to load resource: the server responded with a status of 500 (INTERNAL SERVER ERROR)
frappe-web.min.js:642 Traceback (most recent call last):
  File "/home/frappe/benches/bench-2016-07-23/apps/frappe/frappe/app.py", line 56, in application
    response = frappe.handler.handle()
  File "/home/frappe/benches/bench-2016-07-23/apps/frappe/frappe/handler.py", line 19, in handle
    execute_cmd(cmd)
  File "/home/frappe/benches/bench-2016-07-23/apps/frappe/frappe/handler.py", line 42, in execute_cmd
    ret = frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-2016-07-23/apps/frappe/frappe/__init__.py", line 903, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-2016-07-23/apps/erpnext_com/erpnext_com/api.py", line 66, in signup
    </div>""".format(email), indicator='blue')
TypeError: redirect_to_message() got an unexpected keyword argument 'indicator'

```

Fixing via https://github.com/frappe/frappe/pull/2717, but as urgent solution removing indicator kwarg from api.py
