### PR TITLE
Add footer for gst and vat 

### DIFF
--- a/erpnext_com/hooks.py
+++ b/erpnext_com/hooks.py
@@ -22,7 +22,6 @@ website_context = {
 	# ],
 	"hide_login": 1,
 	"favicon": "/assets/frappe_theme/img/favicon.ico",
-    "sitename": "erpnext"
 }
 
 # Includes in <head>

--- a/erpnext_com/hooks.py
+++ b/erpnext_com/hooks.py
@@ -21,7 +21,7 @@ website_context = {
 	# 	{"label": "Blog", "url": "https://frappe.io/blog", "right":1},
 	# ],
 	"hide_login": 1,
-	"favicon": "/assets/frappe_theme/img/favicon.ico",
+	"favicon": "/assets/frappe_theme/img/favicon.ico"
 }
 
 # Includes in <head>

--- a/erpnext_com/hooks.py
+++ b/erpnext_com/hooks.py
@@ -21,7 +21,8 @@ website_context = {
 	# 	{"label": "Blog", "url": "https://frappe.io/blog", "right":1},
 	# ],
 	"hide_login": 1,
-	"favicon": "/assets/frappe_theme/img/favicon.ico"
+	"favicon": "/assets/frappe_theme/img/favicon.ico",
+    "sitename": "erpnext"
 }
 
 # Includes in <head>

--- a/erpnext_com/templates/includes/footer/footer.html
+++ b/erpnext_com/templates/includes/footer/footer.html
@@ -1,0 +1,77 @@
+<footer>
+    <div class="container">
+    <div class="clearfix">
+            <div class="col-sm-3 col-xs-12">
+                <ul class="list-unstyled footer-list">
+                    <li>
+                        <a href="https://erpnext.com">ERPNext</a>
+                    </li>
+                    <li>
+                        <a href="https://frappe.io">Frappé</a>
+                    </li>
+                    <li>
+                        <a href="https://erpnext.com/mobile">Mobile Apps</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="col-sm-3 col-xs-12">
+                <ul class="list-unstyled footer-list">
+                    <li>
+                        <a href="https://erpnext.com/reseller">Reseller</a>
+                    </li>
+                    <li>
+                        <a href="https://discuss.erpnext.com">Forum</a>
+                    </li>
+                    <li>
+                        <a href="https://github.com/frappe">GitHub</a>
+                    </li>
+                </ul>
+            </div>
+             <div class="col-sm-3 col-xs-12">
+                <ul class="list-unstyled footer-list">
+                 <li>
+                    <a href="https://frappe.io/blog">Blog</a>
+                </li>
+                <li>
+                    <a href="https://frappe.io/about">About</a>
+                </li>
+                <li>
+                    <a href="https://frappe.io/about#contact">Contact</a>
+                </li>
+            </ul>
+            </div>
+             <div class="col-sm-3 col-xs-12">
+                <ul class="list-unstyled footer-list">
+                 <li>
+                    <a href="https://erpnext.com/uae-ksa-vat">UAE/KSA VAT</a>
+                </li>
+                <li>
+                    <a href="https://erpnext.com//india-gst">GST For India</a>
+                </li>
+                </ul>
+             </div>
+             </div>
+             
+ <div class="social">
+                <p>Find us on
+					<a class="underline" href="https://twitter.com/erpnext"
+						target="_blank">Twitter</a>,
+					<a class="underline" href="https://www.facebook.com/ERPNext/"
+						target="_blank">Facebook</a>,
+					<a class="underline" href="https://medium.com/frappé-thoughts/"
+						target="_blank">Medium</a>
+                </p>
+			</div>
+
+            <div class="copyright">
+                <p>
+                    &copy;<span id="year"></span> Frappé Technologies Pvt. Ltd.
+                    Content licensed under
+                    <a class="underline" href="https://creativecommons.org/licenses/by-sa/3.0/" target="_blank">
+						CC-BY-SA 3.0</a>. Read the <a href="https://erpnext.com/terms" class="underline">terms of use</a>.
+                </p>
+            </div>
+        </div>
+	</footer>
+    <!--Javascript-->
+    <script src="/assets/frappe_theme/js/main.js"></script>


### PR DESCRIPTION
This PR adds a 'sitename' variable in hooks.py for conditionally loading footer in erpnext.com and frappe.io

We are loading different footers because erpnext.com has some extra links which are not relevant in frappe.io website. The if statement which evaluates this variable is in footer of the frappe_theme repo and I have sent a separate [pull request](https://github.com/frappe/frappe_theme/pull/12) for frappe_theme. 