### PR TITLE
Correct spacing under plan boxes and add min-height to homepage illustration

### DIFF
--- a/erpnext_com/templates/includes/custom.css
+++ b/erpnext_com/templates/includes/custom.css
@@ -28,7 +28,7 @@
 }
 
 .plan {
-	height: 750px;
+	height: 780px;
 }
 
 .plan .small {
@@ -198,4 +198,3 @@
 .page-container[data-path="proposals"] .page-header-actions-block {
 	margin-top: 20px;
 }
-

--- a/erpnext_com/www/index.css
+++ b/erpnext_com/www/index.css
@@ -46,6 +46,7 @@
 
 .main-illustration {
 	margin: -90px 0 -60px -32px;
+	min-height: 420px;
 }
 
 .hero-title {


### PR DESCRIPTION
Add space under the Pricing boxes and add a minheight to homepage illustration.