### PR TITLE
Fix "Improve Docs" Link

### DIFF
--- a/erpnext_com/www/docs/_sidebar.json
+++ b/erpnext_com/www/docs/_sidebar.json
@@ -16,7 +16,7 @@
   "title": "Videos"
  },
  {
-  "route": "https://github.com/erpnext/foundation/tree/master/foundation/www/docs",
+  "route": "https://github.com/frappe/erpnext_com/tree/master/erpnext_com/www/docs",
   "title": "Improve Docs"
  }
 ]


### PR DESCRIPTION
Updated the link to "Improve Docs". The link pointed to the foundation app, now points to erpnext_com app.