### PR TITLE
Fix Non Profit Module Broken links

### DIFF
--- a/erpnext_com/www/docs/user/manual/en/non_profit/index.md
+++ b/erpnext_com/www/docs/user/manual/en/non_profit/index.md
@@ -6,15 +6,15 @@ People who change the world need the tools to do it! The Non Profit Modules of E
 ## Topics
 
 ##### 1. Membership
-1. [Member](/docs/user/manual/en/non_profit/Membership/member)
-1. [Membership Type](/docs/user/manual/en/non_profit/Membership/membership_type)
-1. [Membership](/docs/user/manual/en/non_profit/Membership/membership)
+1. [Member](/docs/user/manual/en/non_profit/member)
+1. [Membership Type](/docs/user/manual/en/non_profit/membership_type)
+1. [Membership](/docs/user/manual/en/non_profit/membership)
 
 ##### 2. Volunteers and Donors
-1. [Volunteer Type](/docs/user/manual/en/non_profit/Volunteer/volunteer_type)
-1. [Volunteer](/docs/user/manual/en/non_profit/Volunteer/volunteer)
-1. [Donor](/docs/user/manual/en/non_profit/Donor/donor)
-1. [Donor Type](/docs/user/manual/en/non_profit/Donor/donor_type)
+1. [Volunteer Type](/docs/user/manual/en/non_profit/volunteer_type)
+1. [Volunteer](/docs/user/manual/en/non_profit/volunteer)
+1. [Donor](/docs/user/manual/en/non_profit/donor)
+1. [Donor Type](/docs/user/manual/en/non_profit/donor_type)
 
 ##### 3. Grant and Chapter
 1. [Grant Application](/docs/user/manual/en/non_profit/grant-application/)


### PR DESCRIPTION
Person who had changed the topics listing didn't create separate sub-directories for Volunteer, Donor, and Membership, but created the links anyway