### PR TITLE
fix: remove duplicate title tag for FAQ

### DIFF
--- a/erpnext_com/www/pricing/faq.html
+++ b/erpnext_com/www/pricing/faq.html
@@ -1,4 +1,5 @@
 {% extends "frappe_theme/templates/base.html" %}
+{% block title %}ERPNext - Frequently Asked Quetions for Cloud Subscription{% endblock %}
 
 {% block content %}
 


### PR DESCRIPTION
This commit provides a title for the FAQ page to avoid duplication with partner FAQ page:

![image](https://user-images.githubusercontent.com/33246109/62698561-0bf44b00-b9fb-11e9-9e20-c46ea05556ff.png)
