### PR TITLE
fix: meta cleanup for contact page

### DIFF
--- a/erpnext_com/www/contact.html
+++ b/erpnext_com/www/contact.html
@@ -4,18 +4,33 @@
 {% from "erpnext_com/templates/includes/card_grid.html" import card_grid %}
 
 {% block head_include %}
-	<meta name="description" content="ERPNext Contact Details" />
+	<meta name="description" content="Get in touch with the experts of ERPNext to address your queries for Consulting, Support, or Partnerships." />
 	<meta name="keywords" content="ERPNext, Contact, Queries" />
 	<meta name="google-site-verification" content="euiq62LnIrUF6eLvL7wZEnVxhdfkfzuIMnSYRf4JzGk" />
+	<meta name="image" content="https://erpnext.com/assets/erpnext_com/img/home/social.png"/>
+
+	<!-- Open Graph Tags -->	
+
 	<meta property="og:site_name" content="ERPNext"/>
-	<meta itemprop="name" content="Contact Us, Get In Touch, Contact Details">
-	<meta name="title" content="Contact Us, Get In Touch, Contact Details">
-	<meta name="twitter:title" content="Contact Us, Get In Touch,, Contact Details, Get in touch with the experts of ERPNext">
-	<meta property="og:title" content="Contact Us, Get In Touch,, Contact Details, Get in touch with the experts of ERPNext”/>
-	<meta name="twitter:description" content="Contact Us, Get In Touch, Contact Details, Get in touch with the experts of ERPNext">
-	<meta name="description" content="Contact Us, Get In Touch, Contact Details, Get in touch with the experts of ERPNext">
-	<meta property="og:description" content="Contact Us, Get In Touch, Contact Details, Get in touch with the experts of ERPNext">
-							 
+	<meta property="og:title" content="Contact Us | ERPNext"/>
+	<meta property="og:description" content="Get in touch with the experts of ERPNext to address your queries for Consulting, Support, or Partnerships." />					   
+	<meta property="og:image" content="https://erpnext.com/assets/erpnext_com/img/home/social.png" />
+	<meta property="og:type" content="website" />			   
+
+	<!-- Twitter Tags -->
+													
+	<meta name="twitter:card" content="summary_large_image">					  
+	<meta name="twitter:title" content="Contact Us | ERPNext">
+	<meta name="twitter:description" content="Get in touch with the experts of ERPNext to address your queries for Consulting, Support, or Partnerships.">
+	<meta name="twitter:image" content="https://erpnext.com/assets/erpnext_com/img/home/social.png">
+												      
+												     
+	<!-- Schema.org Markup -->
+
+	<meta itemprop="name" content="Contact Us | ERPNext">
+	<meta itemprop="description" content="Get in touch with the experts of ERPNext to address your queries for Consulting, Support, or Partnerships.">
+	<meta itemprop="image" content="https://erpnext.com/assets/erpnext_com/img/home/social.png">
+
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
Current page previews generated:

![image](https://user-images.githubusercontent.com/33246109/76676653-c8df0380-65eb-11ea-8838-0e60c0a3a7aa.png)

![image](https://user-images.githubusercontent.com/33246109/76676665-d8f6e300-65eb-11ea-8fa3-90001a4d359c.png)

