### PR TITLE
fix: redirect to signup relatively

### DIFF
--- a/erpnext_com/templates/includes/macros.html
+++ b/erpnext_com/templates/includes/macros.html
@@ -90,7 +90,7 @@
 			<p>Space: {{ space }} GB</p>
 			<p>Functional Support</p>
 			<div class='trial'>
-				<button class="btn btn-primary" onclick="redirect_to_signup('signup', '{{ plan_name }}')" > Start Trial </button>
+				<button class="btn btn-primary" onclick="redirect_to_signup('/signup', '{{ plan_name }}')" > Start Trial </button>
 			</div>
 		</div>
 	</div>

--- a/erpnext_com/www/pricing/index.html
+++ b/erpnext_com/www/pricing/index.html
@@ -14,7 +14,7 @@
 	<h2>{{ symbol }} {{ monthly_amount|int }}</h2>
 	<p class='text-muted mb-1' style="min-height: 50px; width: 90%">Per user per month or {{ symbol }}{{ amount|int }} yearly</p>
 	<button class='btn btn-primary mt-2 btn-sm'
-		onclick="redirect_to_signup('signup', '{{ name }}')">Start 14 Day Trial</button>
+		onclick="redirect_to_signup('/signup', '{{ name }}')">Start 14 Day Trial</button>
 	<p class='text-muted small mt-2'>Minimum {{ minimum_users }} Users</p>
 </div>
 {% endmacro %}


### PR DESCRIPTION
fixes issue where going to `https://erpnext.com/pricing/` and clicking on signup would redirect to `https://erpnext.com/pricing/signup`, instead of redirecting to `https://erpnext.com/signup`.

specifying a `/` before the redirect path ensures that the url that it redirects to is `/signup` and not `/pricing/signup`

![unnamed](https://user-images.githubusercontent.com/11243138/77309714-24636c80-6d23-11ea-9599-e2c62ed4ca81.gif)
